### PR TITLE
update to zig 0.15.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-zig-cache/
+.zig-cache/

--- a/build.zig
+++ b/build.zig
@@ -1,19 +1,26 @@
 const std = @import("std");
 pub fn build(b: *std.Build) !void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
     const benchmark = b.addModule("benchmark", .{
         .root_source_file = b.path("benchmark.zig"),
+        .target = target,
+        .optimize = optimize,
     });
 
     try b.modules.put(b.dupe("benchmark"), benchmark);
 
     // example exe and run
-    var example_exe = b.addExecutable(.{
+    const example_exe = b.addExecutable(.{
         .name = "example",
-        .root_source_file = b.path("example.zig"),
-        .target = b.standardTargetOptions(.{}),
-        .optimize = b.standardOptimizeOption(.{}),
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("example.zig"),
+            .target = target,
+            .optimize = optimize,
+            .imports = &.{.{ .name = "benchmark", .module = benchmark }},
+        }),
     });
-    example_exe.root_module.addImport("benchmark", benchmark);
 
     const example_run_step = b.step("run", "run the example");
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,7 @@
 .{
-    .name = "benchmark",
+    .name = .benchmark,
     .version = "0.1.0",
-    .min_zig_version = "0.12.0",
+    .fingerprint = 0xb70c48fec4e91ce4,
+    .min_zig_version = "0.15.1",
     .paths = .{""},
 }

--- a/example.zig
+++ b/example.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const benchmark = @import("benchmark");
+
 pub const main = benchmark.main(.{}, struct {
     // Benchmarks are just public functions
     pub fn arrayListWriter(b: *benchmark.B) !void {
@@ -10,11 +11,11 @@ pub const main = benchmark.main(.{}, struct {
         while (b.step()) { // Number of iterations is automatically adjusted for accurate timing
             defer _ = arena.reset(.retain_capacity);
 
-            var a = std.ArrayList(u8).init(arena.allocator());
-            try a.writer().print("Hello, {s}!", .{"world"});
+            var a: std.Io.Writer.Allocating = .init(arena.allocator());
+            try a.writer.print("Hello, {s}!", .{"world"});
 
             // `use` is a helper that calls `std.mem.doNotOptimizeAway`
-            b.use(a.items);
+            b.use(a.written());
         }
     }
 


### PR DESCRIPTION
zig-bson uses this library and it can't be updated to 0.15.1 until this library is updated.
And I'd like to use zig-bson for a project I'm working on.

EDIT: I've chosen not to use BSON, but this PR still stands.